### PR TITLE
feat: proxy spider; debug spider; 数据库保存

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Data Crawler
 
-### 项目结构
+## 项目结构
 
 ```shell
 .
@@ -29,9 +29,9 @@
 └── test_files # 暂时存储爬取结果
 ```
 
-### 运行爬虫
+## 运行爬虫
 
-#### IEEE random paper crawler
+### IEEE random paper crawler
 
 ```shell
 scrapy crawl ieee
@@ -41,7 +41,7 @@ scrapy crawl ieee
 
 由于暂时使用随机爬取，和proxy判断有冲突，如果进行，建议不使用存活率低proxy，可以1. 确保proxies的存活率比较高 2. 将proxies.txt置为空，即不使用proxy
 
-#### ACM paper in search result crawler
+### ACM paper in search result crawler
 
 ```shell
 scrapy crawl ACM_Paper
@@ -51,15 +51,15 @@ scrapy crawl ACM_Paper
 
 暂时未实现关键词爬取。
 
-#### IEEE conferences crawler
+### IEEE conferences crawler
 
-##### command
+#### command
 
 ```shell
 scrapy crawl IEEE_Paper
 ```
 
-##### settings
+#### settings
 
 /data_crawler/settings.py
 
@@ -73,19 +73,19 @@ IEEE_YEAR = {
 }
 ```
 
-##### result
+#### result
 
 IEEE_CONF_URLS中所有会议在IEEE_YEAR范围内的所有文章
 
-#### ACM proceeding crawler
+### ACM proceeding crawler
 
-##### command
+#### command
 
 ```shell
 scrapy crawl ACM_Proceedings
 ```
 
-##### settings
+#### settings
 
 /data_crawler/settings.py
 
@@ -95,13 +95,161 @@ ACM_PROCEEDING_URL = ['https://dl.acm.org/doi/proceedings/10.1145/3238147']
 
 可以是多个proceeding
 
-##### result
+#### result
 
 爬取settings中所有proceeding的所有文章
 
-### 结果查看
+### DEBUG crawler
 
-存储结果保存在 /test_files/crawled_items.json中
+为了节约时间，模拟spider向pipeline发送数据，用于对pipeline的debug。直接读取之前爬取的内容，然后作为item传给pipeline处理。
+
+#### command
+
+```shell
+scrapy crawl debug
+```
+
+#### settings
+
+在test_files/crawled_items_debug.json中放入之前爬的raw json结果
+
+#### result
+
+等于不实际发送请求，而是把之前的结果再次发送给pipeline处理
+
+## 结果查看
+
+### Raw Json File
+
+存储结果保存在 /test_files/crawled_items.json中。其中是没有经过处理的所有spider传回的item
+
+### Database
+
+存储于数据库data_processing表中。
+
+#### setting
+
+如要启动数据库保存，需要在/data_crawler/settings中设置:
+
+1. 配置数据库用户名密码等
+
+   ```python
+   # Database
+   MYSQL_HOST = 'localhost'
+   MYSQL_DBNAME = 'data_processing'
+   MYSQL_USER = 'root'
+   MYSQL_PASSWORD = 'root'
+   MYSQL_PORT = 3306
+   ```
+
+2. 启动MysqlPipeline(确保'data_crawler.pipelines.MysqlPipeline': 889的最后这个数字不是None)
+
+   ```python
+   ITEM_PIPELINES = {
+       'data_crawler.pipelines.RemoveEmptyItemPipeline': 500,
+    'data_crawler.pipelines.JsonWriterPipeline': 888 if not DEBUG else None,
+       'data_crawler.pipelines.MysqlPipeline': 889,
+   }
+   ```
+   
+
+#### 数据库初始化
+
+进入Mysql之后运行 source /absolute/path/data_processing.sql (或者在data_processing根目录下进入mysql，可以写相对路径)
+
+**注意此操作会将原名为data_processing的数据库删库**
+
+#### 数据库基本结构
+
+##### 1. affiliation
+
+TODO: 目前来看，ieee没有affliation的页面，因此也似乎没有内部id，怎么处理暂时不清楚。暂时用name来作为IEEE affiliation的id
+
+| 序号 |     名称      |                描述                 |     类型      |  键  | 为空 | 额外 | 默认值 |
+| :--: | :-----------: | :---------------------------------: | :-----------: | :--: | :--: | :--: | :----: |
+|  1   |     `id`      | ACM_{ACM内部id}或IEEE__{IEEE内部id} | varchar(255)  | PRI  |  NO  |      |        |
+|  2   |    `name`     |                                     | varchar(255)  |      |  NO  |      |        |
+|  3   | `description` |                                     | varchar(4095) |      | YES  |      |        |
+
+##### 2. domain
+
+| 序号 |  名称  |        描述        |     类型     |  键  | 为空 | 额外 | 默认值 |
+| :--: | :----: | :----------------: | :----------: | :--: | :--: | :--: | :----: |
+|  1   |  `name`  | 暂时以名字作为主键 | varchar(255) | PRI  |  NO  |      |        |
+|  2   | `url` | 如果是ACM则有url | varchar(255) |      | YES |      |        |
+
+##### 3. paper
+
+| 序号 |        名称        |        描述        |     类型      |  键  | 为空 | 额外 | 默认值 |
+| :--: | :----------------: | :----------------: | :-----------: | :--: | :--: | :--: | :----: |
+|  1   |        `id`        |    文章的doi号     | varchar(255)  | PRI  |  NO  |      |        |
+|  2   |      `title`       |                    | varchar(255)  |      |  NO  |      |        |
+|  3   |       `abs`        |      abstract      | varchar(4095) |      |  NO  |      |        |
+|  4   |  `publication_id`  |  发表的会议的doi   | varchar(255)  |      |  NO  |      |        |
+|  5   | `publication_date` | 发表年份，事实上和publication表冗余，但是为了方便还是直接存了 | varchar(255)  |      |  NO  |      |        |
+|  6   |       `link`       | 事实上是doi.org/{paper_doi} | varchar(255)  |      |  NO  |      |        |
+
+##### 4. paper_domain
+
+| 序号 |  名称   |    描述     |     类型     |  键  | 为空 | 额外 | 默认值 |
+| :--: | :-----: | :---------: | :----------: | :--: | :--: | :--: | :----: |
+|  1   |  `pid`  |  paper id   | varchar(255) | PRI  |  NO  |      |        |
+|  2   | `dname` | domain name | varchar(255) | PRI  |  NO  |      |        |
+
+##### 5. researcher
+
+| 序号 |  名称  |                             描述                             |     类型     |  键  | 为空 | 额外 | 默认值 |
+| :--: | :----: | :----------------------------------------------------------: | :----------: | :--: | :--: | :--: | :----: |
+|  1   |  `id`  | ACM_{ACM内部id}或IEEE__{IEEE内部id}，如IEEE_37085628262，说明其主页是https://ieeexplore.ieee.org/author/37085628262 | varchar(255) | PRI  |  NO  |      |        |
+|  2   | `name` |                                                              | varchar(255) |      |  NO  |      |        |
+
+##### 6. paper_reference
+
+注意，这里的reference是所有能够获得doi的文章，其他的reference被忽略；另外很可能这个doi不在爬取的范围内，既在paper表中没有这个doi。
+
+| 序号 |      名称       |        描述         |     类型     |  键  | 为空 | 额外 | 默认值 |
+| :--: | :-------------: | :-----------------: | :----------: | :--: | :--: | :--: | :----: |
+|  1   |      `pid`      |   paper id（doi）   | varchar(255) | PRI  |  NO  |      |        |
+|  2   | `reference_doi` | reference paper doi | varchar(255) | PRI  |  NO  |      |        |
+
+##### 7. paper_researcher
+
+| 序号 |  名称   |     描述      |     类型     |  键  | 为空 | 额外 | 默认值 |
+| :--: | :-----: | :-----------: | :----------: | :--: | :--: | :--: | :----: |
+|  1   |  `pid`  |   paper id    | varchar(255) | PRI  |  NO  |      |        |
+|  2   |  `rid`  | researcher id | varchar(255) | PRI  |  NO  |      |        |
+|  3   | `order` |   第几作者    | varchar(255) |      |  NO  |      |        |
+
+##### 8. publication
+
+TODO: 目前不确定是否所有的会议都有doi，如果没有的话考虑通过其他方式存储
+
+TODO: 目前对IEEE的处理是将title作为id保存，目前不确定是否能从ieee获得会议doi
+
+| 序号 |        名称        |                             描述                             |     类型     |  键  | 为空 | 额外 | 默认值 |
+| :--: | :----------------: | :----------------------------------------------------------: | :----------: | :--: | :--: | :--: | :----: |
+|  1   |        `id`        | 会议doi。注意是具体某一年的会议，比如第34届ASE，不是历年的ASE汇总的（那个可能没有doi） | varchar(255) | PRI  |  NO  |      |        |
+|  2   |       `name`       |                                                              | varchar(255) |      |  NO  |      |        |
+|  3   | `publication_date` |                          发表的年份                          | varchar(255) |      |  NO  |      |        |
+|  4   |      `impact`      |            影响力因子（TODO:目前不知道怎么获得）             | varchar(255) |      |  NO  |      |        |
+
+##### 9. researcher_affiliation
+
+| 序号 | 名称  |      描述      |     类型     |  键  | 为空 | 额外 | 默认值 |
+| :--: | :---: | :------------: | :----------: | :--: | :--: | :--: | :----: |
+|  1   | `rid` | researcher id  | varchar(255) | PRI  |  NO  |      |        |
+|  2   | `aid` | affiliation id | varchar(255) | PRI  |  NO  |      |        |
+
+##### 10. researcher_domain
+
+| 序号 |  名称   |     描述      |     类型     |  键  | 为空 | 额外 | 默认值 |
+| :--: | :-----: | :-----------: | :----------: | :--: | :--: | :--: | :----: |
+|  1   |  `rid`  | researcher id | varchar(255) | PRI  |  NO  |      |        |
+|  2   | `dname` |  domain name  | varchar(255) | PRI  |  NO  |      |        |
+
+
+
+## 其他设置
 
 ### Log
 
@@ -114,3 +262,4 @@ log保存在 /scrapy_logs中
 格式为一行一个，ip:端口号
 
 如果不需要代理则在settings中将rotating_proxies.middlewares.RotatingProxyMiddleware、rotating_proxies.middlewares.BanDetectionMiddleware两个中间件禁用
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Data Crawler
 
+## Requirements
+
+python 3.6.9
+
+8.0.20 MySQL Community Server - GPL
+
+other python packages in requirements.txt
+
 ## 项目结构
 
 ```shell
@@ -37,7 +45,7 @@
 scrapy crawl ieee
 ```
 
-随机爬取5篇ieee论文（由于暂时未设置代理，为避免ip封锁，暂时只爬取五篇，如果需要修改，在ieee_paper_spider.py中修改）
+随机爬取5篇IEEE论文（由于暂时未设置代理，为避免ip封锁，暂时只爬取五篇，如果需要修改，在IEEE_paper_spider.py中修改）
 
 由于暂时使用随机爬取，和proxy判断有冲突，如果进行，建议不使用存活率低proxy，可以1. 确保proxies的存活率比较高 2. 将proxies.txt置为空，即不使用proxy
 

--- a/data_crawler/pipelines.py
+++ b/data_crawler/pipelines.py
@@ -11,6 +11,12 @@ import json
 from data_crawler.items import IEEEPaperItem
 from scrapy.exceptions import DropItem
 
+import pymysql
+import datetime
+from twisted.enterprise import adbapi
+import logging
+
+
 class DataCrawlerPipeline:
     def process_item(self, item, spider):
         return item
@@ -39,3 +45,106 @@ class JsonWriterPipeline:
         line = json.dumps(ItemAdapter(item).asdict()) + "\n"
         self.file.write(line)
         return item
+
+class MysqlPipeline(object):
+    def __init__(self, dbpool):
+        self.dbpool = dbpool
+
+    @classmethod
+    def from_settings(cls, settings):  # 函数名固定，会被scrapy调用，直接可用settings的值
+        """
+        数据库建立连接
+        :param settings: 配置参数
+        :return: 实例化参数
+        """
+        adbparams = dict(
+            host=settings['MYSQL_HOST'],
+            db=settings['MYSQL_DBNAME'],
+            user=settings['MYSQL_USER'],
+            password=settings['MYSQL_PASSWORD'],
+            cursorclass=pymysql.cursors.DictCursor  # 指定cursor类型
+        )
+        # 连接数据池ConnectionPool，使用pymysql连接
+        dbpool = adbapi.ConnectionPool('pymysql', **adbparams)
+        # 返回实例化参数
+        return cls(dbpool)
+
+    def process_item(self, item, spider):
+        """
+        使用twisted将MySQL插入变成异步执行。通过连接池执行具体的sql操作，返回一个对象
+        """
+        
+        query = self.dbpool.runInteraction(self.do_insert_IEEE_paper, item)  # 指定操作方法和操作数据
+        # 添加异常处理
+        query.addCallback(self.handle_error)  # 处理异常
+
+    def do_insert_IEEE_paper(self, cursor, item):
+        """
+        对数据库插入一篇文章，并不需要commit，twisted会自动commit
+        """
+        # paper
+        insert_sql = """
+            insert into paper(id, title, abs, publication, publication_date, link) VALUES(%s,%s,%s,%s,%s,%s)
+                    """
+        self.execute_sql(
+            insert_sql, 
+            (item['doi'], item['title'], item['abstract'], item['publicationTitle'], item['publicationYear'], 'doi.org/' + item['doi']),
+            cursor,
+            self.merge_paper,
+            (item,)
+        )
+
+        # researcher paper_researcher
+        # 学者的id为 数据库名_数据库内部ID 如IEEE_37086831215
+        order = 0
+        for author in item['authors']:
+            order += 1
+
+            # researcher
+            insert_author_sql = """
+                            insert into researcher(`id`, `name`) VALUES(%s, %s)
+                            """
+            self.execute_sql(
+                insert_author_sql,
+                ('IEEE_' + author['id'], author['name']),
+                cursor
+            )
+
+            # paper_researcher
+            insert_paper_researcher_sql = """
+                            insert into paper_researcher(`pid`, `rid`, `order`) VALUES(%s, %s, %s)
+                            """
+            self.execute_sql(
+                insert_paper_researcher_sql,
+                (item['doi'], 'IEEE_' + author['id'], order),
+                cursor,
+            )
+
+    @staticmethod
+    def execute_sql(sql, values, cursor, callback_dulp_key = None, callback_dulp_key_args = None):
+        """
+        callback_dupl_key是插入数据库时发现key重复时的回调函数(当且仅当传了这个参数)
+        callback_dulp_key_args是一个iterable, unpack之后作为callback_dulp_key's arguments 
+        """
+        try:
+            cursor.execute(sql, values)
+        except pymysql.err.IntegrityError as e:
+            if(e.args[0] == 1062) and (callback_dulp_key != None):
+                # 1062是pymysql duplicate key的错误码
+                callback_dulp_key(*callback_dulp_key_args)   
+            else:
+                # TODO: other exceptions
+                logging.warning(e)
+
+    def merge_paper(self, item):
+        """
+        TODO:发现IEEE ACM的重复文章，合并其中的所有作者、所有affliation
+        """
+        pass
+
+    def handle_error(self, failure):
+        if failure:
+            # 打印错误信息
+            print(failure)
+            logging.error('$ messages from MysqlPipeline: ' + str(failure))
+

--- a/data_crawler/settings.py
+++ b/data_crawler/settings.py
@@ -113,7 +113,7 @@ DOWNLOADER_MIDDLEWARES = {
 
 ITEM_PIPELINES = {
     'data_crawler.pipelines.RemoveEmptyItemPipeline': 500,
-    'data_crawler.pipelines.JsonWriterPipeline': 888 if not DEBUG else None,
+    'data_crawler.pipelines.JsonWriterPipeline': 888,
     'data_crawler.pipelines.MysqlPipeline': 889,
 }
 # Enable or disable extensions

--- a/data_crawler/settings.py
+++ b/data_crawler/settings.py
@@ -14,7 +14,7 @@ import rotating_proxies
 import os
 
 # 是否为debug模式，如果是, 不使用proxy
-DEBUG = False
+DEBUG = True
 
 tem_dir=['scrapy_logs', 'test_files']
 for dir in tem_dir:
@@ -103,9 +103,8 @@ ROTATING_PROXY_PAGE_RETRY_TIMES = 30
 # Enable or disable downloader middlewares
 # See https://docs.scrapy.org/en/latest/topics/downloader-middleware.html
 
-
 DOWNLOADER_MIDDLEWARES = {
-    'data_crawler.middlewares.RandomUserAgentMiddleware': 400,
+    'data_crawler.middlewares.RandomUserAgentMiddleware': 400 if not DEBUG else None,
     'rotating_proxies.middlewares.RotatingProxyMiddleware': 610 if not DEBUG else None,
     'rotating_proxies.middlewares.BanDetectionMiddleware': 620 if not DEBUG else None,
     'data_crawler.middlewares.RequestLogMiddleware': None,
@@ -114,7 +113,7 @@ DOWNLOADER_MIDDLEWARES = {
 
 ITEM_PIPELINES = {
     'data_crawler.pipelines.RemoveEmptyItemPipeline': 500,
-    'data_crawler.pipelines.JsonWriterPipeline': 888,
+    'data_crawler.pipelines.JsonWriterPipeline': 888 if not DEBUG else None,
     'data_crawler.pipelines.MysqlPipeline': 889,
 }
 # Enable or disable extensions

--- a/data_crawler/settings.py
+++ b/data_crawler/settings.py
@@ -38,6 +38,12 @@ IEEE_YEAR = {
     'from': 2019,
     'to': 2019
 }
+# Database
+MYSQL_HOST = 'localhost'
+MYSQL_DBNAME = 'data_processing'
+MYSQL_USER = 'root'
+MYSQL_PASSWORD = 'root'
+MYSQL_PORT = 3306
 
 #HTTPERROR_ALLOWED_CODES  =[400]
 
@@ -109,6 +115,7 @@ DOWNLOADER_MIDDLEWARES = {
 ITEM_PIPELINES = {
     'data_crawler.pipelines.RemoveEmptyItemPipeline': 500,
     'data_crawler.pipelines.JsonWriterPipeline': 888,
+    'data_crawler.pipelines.MysqlPipeline': 889,
 }
 # Enable or disable extensions
 # See https://docs.scrapy.org/en/latest/topics/extensions.html

--- a/data_crawler/settings.py
+++ b/data_crawler/settings.py
@@ -45,7 +45,7 @@ IEEE_YEAR = {
 START_TIME = datetime.datetime.now()
 
 # LOG
-LOG_LEVEL = 'INFO'
+LOG_LEVEL = 'DEBUG'
 LOG_FILE = 'scrapy_logs/Scrapy_{}_{}_{}_{}_{}_{}.log'.format(START_TIME.year, START_TIME.month, START_TIME.day, START_TIME.hour, START_TIME.minute, START_TIME.second)
 
 # Retry Setting
@@ -91,6 +91,8 @@ AUTOTHROTTLE_ENABLED = True
 
 # rataing_proxy
 ROTATING_PROXY_LIST_PATH = 'proxies.txt'
+#a number of times to retry downloading a page using a different proxy. After this amount of retries failure is considered a page failure, not a proxy failure. Think of it this way: every improperly detected ban cost you ROTATING_PROXY_PAGE_RETRY_TIMES alive proxies. Default: 5.
+ROTATING_PROXY_PAGE_RETRY_TIMES = 30 
 
 # Enable or disable downloader middlewares
 # See https://docs.scrapy.org/en/latest/topics/downloader-middleware.html

--- a/data_crawler/settings.py
+++ b/data_crawler/settings.py
@@ -104,7 +104,7 @@ ROTATING_PROXY_PAGE_RETRY_TIMES = 30
 # See https://docs.scrapy.org/en/latest/topics/downloader-middleware.html
 
 DOWNLOADER_MIDDLEWARES = {
-    'data_crawler.middlewares.RandomUserAgentMiddleware': 400 if not DEBUG else None,
+    'data_crawler.middlewares.RandomUserAgentMiddleware': 400,
     'rotating_proxies.middlewares.RotatingProxyMiddleware': 610 if not DEBUG else None,
     'rotating_proxies.middlewares.BanDetectionMiddleware': 620 if not DEBUG else None,
     'data_crawler.middlewares.RequestLogMiddleware': None,

--- a/data_crawler/spiders/debug_spider.py
+++ b/data_crawler/spiders/debug_spider.py
@@ -1,0 +1,18 @@
+import json
+
+import scrapy
+
+class DebugSpider(scrapy.Spider):
+    """
+    用于debug，直接读取之前爬取的内容，然后作为item传给pipeline处理
+    """
+    name = "debug"
+
+    def start_requests(self):
+        yield scrapy.Request('http://quotes.toscrape.com/page/1/')
+    
+    def parse(self, response):
+        with open('test_files/crawled_items_debug.json') as f:
+            for line in f:
+                item = json.loads(line)
+                yield item

--- a/data_crawler/spiders/ieee_spider.py
+++ b/data_crawler/spiders/ieee_spider.py
@@ -35,7 +35,9 @@ class IEEESpider(scrapy.Spider):
                 callback=self.parse_conference_list,
                 headers={
                     'Referer': url,
-                    'Host': 'ieeexplore.ieee.org'
+                    'Host': 'ieeexplore.ieee.org',
+                    'Origin': self.ieee_base_url,
+                    'Content-Type': 'application/json'
                 },
             )
     

--- a/data_crawler/spiders/proxy_spider.py
+++ b/data_crawler/spiders/proxy_spider.py
@@ -1,0 +1,26 @@
+import json
+import logging
+
+import scrapy
+
+from data_crawler.spiders.utils import save_str_file
+
+from scrapy.utils.project import get_project_settings
+
+class ProxySpider(scrapy.Spider):
+    """
+    crawl proxies from https://www.kuaidaili.com/free/, stored in text_filex/proxies.txt
+    """
+
+    name = 'kuai_proxy'
+    start_urls = ['https://www.kuaidaili.com/free/']
+
+    def parse(self, response):
+        proxy_ips = response.xpath('.//div[@id="list"]/table/tbody/tr/td[@data-title="IP"]/text()').getall()
+        proxy_ports = response.xpath('.//div[@id="list"]/table/tbody/tr/td[@data-title="PORT"]/text()').getall()
+        result = ''
+        for i in range(len(proxy_ips)):
+            result += proxy_ips[i] + ':' + proxy_ports[i] + '\n'
+        save_str_file(result, 'proxies.txt')
+        yield None
+

--- a/data_processing.sql
+++ b/data_processing.sql
@@ -6,22 +6,22 @@ CREATE TABLE `paper` (
     `id` varchar(255) NOT NULL,
     `title` varchar(255) COLLATE utf8_bin NOT NULL,
     `abs` varchar(4095) COLLATE utf8_bin NOT NULL,
-    `publication` varchar(255) COLLATE utf8_bin NOT NULL,
+    `publication_id` varchar(255) COLLATE utf8_bin NOT NULL,
     `publication_date` varchar(255) COLLATE utf8_bin NOT NULL,
     `link` varchar(255) COLLATE utf8_bin NOT NULL,
     PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
 CREATE TABLE `domain` (
-    `id` varchar(255) NOT NULL,
     `name` varchar(255) COLLATE utf8_bin NOT NULL,
-    PRIMARY KEY (`id`)
+    `url` varchar(255) COLLATE utf8_bin,
+    PRIMARY KEY (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
 CREATE TABLE `affiliation` (
     `id` varchar(255) NOT NULL,
     `name` varchar(255) COLLATE utf8_bin NOT NULL,
-    `description` varchar(4095) COLLATE utf8_bin NOT NULL,
+    `description` varchar(4095) COLLATE utf8_bin,
     PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
@@ -49,14 +49,14 @@ CREATE TABLE `paper_researcher` (
 
 CREATE TABLE `paper_reference` (
     `pid` varchar(255) COLLATE utf8_bin NOT NULL,
-    `reference_pid` varchar(255) COLLATE utf8_bin NOT NULL,
-    PRIMARY KEY (`pid`, `reference_pid`)
+    `reference_doi` varchar(255) COLLATE utf8_bin NOT NULL,
+    PRIMARY KEY (`pid`, `reference_doi`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
 CREATE TABLE `paper_domain` (
     `pid` varchar(255) COLLATE utf8_bin NOT NULL,
-    `did` varchar(255) COLLATE utf8_bin NOT NULL,
-    PRIMARY KEY (`pid`, `did`)
+    `dname` varchar(255) COLLATE utf8_bin NOT NULL,
+    PRIMARY KEY (`pid`, `dname`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
 CREATE TABLE `paper_publication` (
@@ -67,8 +67,8 @@ CREATE TABLE `paper_publication` (
 
 CREATE TABLE `researcher_domain` (
     `rid` varchar(255) COLLATE utf8_bin NOT NULL,
-    `did` varchar(255) COLLATE utf8_bin NOT NULL,
-    PRIMARY KEY (`rid`, `did`)
+    `dname` varchar(255) COLLATE utf8_bin NOT NULL,
+    PRIMARY KEY (`rid`, `dname`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
 CREATE TABLE `researcher_affiliation` (

--- a/data_processing.sql
+++ b/data_processing.sql
@@ -2,17 +2,17 @@ DROP DATABASE IF EXISTS data_processing;
 CREATE DATABASE data_processing;
 USE data_processing;
 
-CREATE TABLE `papers` (
+CREATE TABLE `paper` (
     `id` varchar(255) NOT NULL,
     `title` varchar(255) COLLATE utf8_bin NOT NULL,
     `abs` varchar(4095) COLLATE utf8_bin NOT NULL,
     `publication` varchar(255) COLLATE utf8_bin NOT NULL,
-    `publicationDate` varchar(255) COLLATE utf8_bin NOT NULL,
+    `publication_date` varchar(255) COLLATE utf8_bin NOT NULL,
     `link` varchar(255) COLLATE utf8_bin NOT NULL,
     PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
-CREATE TABLE `domains` (
+CREATE TABLE `domain` (
     `id` varchar(255) NOT NULL,
     `name` varchar(255) COLLATE utf8_bin NOT NULL,
     PRIMARY KEY (`id`)
@@ -41,44 +41,38 @@ CREATE TABLE `researcher` (
 
 
 CREATE TABLE `paper_researcher` (
-    `id` varchar(255) NOT NULL,
     `pid` varchar(255) COLLATE utf8_bin NOT NULL,
     `rid` varchar(255) COLLATE utf8_bin NOT NULL,
     `order` varchar(255) COLLATE utf8_bin NOT NULL,
-    PRIMARY KEY (`id`)
+    PRIMARY KEY (`pid`, `rid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
 CREATE TABLE `paper_reference` (
-    `id` varchar(255) NOT NULL,
     `pid` varchar(255) COLLATE utf8_bin NOT NULL,
-    `rid` varchar(255) COLLATE utf8_bin NOT NULL,
-    PRIMARY KEY (`id`)
+    `reference_pid` varchar(255) COLLATE utf8_bin NOT NULL,
+    PRIMARY KEY (`pid`, `reference_pid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
 CREATE TABLE `paper_domain` (
-    `id` varchar(255) NOT NULL,
     `pid` varchar(255) COLLATE utf8_bin NOT NULL,
     `did` varchar(255) COLLATE utf8_bin NOT NULL,
-    PRIMARY KEY (`id`)
+    PRIMARY KEY (`pid`, `did`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
 CREATE TABLE `paper_publication` (
-    `id` varchar(255) NOT NULL,
     `paper_id` varchar(255) COLLATE utf8_bin NOT NULL,
     `publication_id` varchar(255) COLLATE utf8_bin NOT NULL,
-    PRIMARY KEY (`id`)
+    PRIMARY KEY (`paper_id`, `publication_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
 CREATE TABLE `researcher_domain` (
-    `id` varchar(255) NOT NULL,
     `rid` varchar(255) COLLATE utf8_bin NOT NULL,
     `did` varchar(255) COLLATE utf8_bin NOT NULL,
-    PRIMARY KEY (`id`)
+    PRIMARY KEY (`rid`, `did`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
 CREATE TABLE `researcher_affiliation` (
-    `id` varchar(255) NOT NULL,
     `rid` varchar(255) COLLATE utf8_bin NOT NULL,
     `aid` varchar(255) COLLATE utf8_bin NOT NULL,
-    PRIMARY KEY (`id`)
+    PRIMARY KEY (`rid`, `aid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;

--- a/data_processing.sql
+++ b/data_processing.sql
@@ -1,0 +1,84 @@
+DROP DATABASE IF EXISTS data_processing;
+CREATE DATABASE data_processing;
+USE data_processing;
+
+CREATE TABLE `papers` (
+    `id` varchar(255) NOT NULL,
+    `title` varchar(255) COLLATE utf8_bin NOT NULL,
+    `abs` varchar(4095) COLLATE utf8_bin NOT NULL,
+    `publication` varchar(255) COLLATE utf8_bin NOT NULL,
+    `publicationDate` varchar(255) COLLATE utf8_bin NOT NULL,
+    `link` varchar(255) COLLATE utf8_bin NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+
+CREATE TABLE `domains` (
+    `id` varchar(255) NOT NULL,
+    `name` varchar(255) COLLATE utf8_bin NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+
+CREATE TABLE `affiliation` (
+    `id` varchar(255) NOT NULL,
+    `name` varchar(255) COLLATE utf8_bin NOT NULL,
+    `description` varchar(4095) COLLATE utf8_bin NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+
+CREATE TABLE `publication` (
+    `id` varchar(255) NOT NULL,
+    `name` varchar(255) COLLATE utf8_bin NOT NULL,
+    `publication_date` varchar(255) COLLATE utf8_bin NOT NULL,
+    `impact` varchar(255) COLLATE utf8_bin NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+
+CREATE TABLE `researcher` (
+    `id` varchar(255) NOT NULL,
+    `name` varchar(255) COLLATE utf8_bin NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+
+
+CREATE TABLE `paper_researcher` (
+    `id` varchar(255) NOT NULL,
+    `pid` varchar(255) COLLATE utf8_bin NOT NULL,
+    `rid` varchar(255) COLLATE utf8_bin NOT NULL,
+    `order` varchar(255) COLLATE utf8_bin NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+
+CREATE TABLE `paper_reference` (
+    `id` varchar(255) NOT NULL,
+    `pid` varchar(255) COLLATE utf8_bin NOT NULL,
+    `rid` varchar(255) COLLATE utf8_bin NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+
+CREATE TABLE `paper_domain` (
+    `id` varchar(255) NOT NULL,
+    `pid` varchar(255) COLLATE utf8_bin NOT NULL,
+    `did` varchar(255) COLLATE utf8_bin NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+
+CREATE TABLE `paper_publication` (
+    `id` varchar(255) NOT NULL,
+    `paper_id` varchar(255) COLLATE utf8_bin NOT NULL,
+    `publication_id` varchar(255) COLLATE utf8_bin NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+
+CREATE TABLE `researcher_domain` (
+    `id` varchar(255) NOT NULL,
+    `rid` varchar(255) COLLATE utf8_bin NOT NULL,
+    `did` varchar(255) COLLATE utf8_bin NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+
+CREATE TABLE `researcher_affiliation` (
+    `id` varchar(255) NOT NULL,
+    `rid` varchar(255) COLLATE utf8_bin NOT NULL,
+    `aid` varchar(255) COLLATE utf8_bin NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fake-useragent==0.1.11
 scrapy==2.3.0
 scrapy-rotating-proxies==0.6.2
+Twisted==20.3.0


### PR DESCRIPTION
1. proxy spider
爬取“快代理”网站的proxy保存为文件
2. debug spider
为了节约时间，模拟spider向pipeline发送数据，用于对pipeline的debug。直接读取之前爬取的内容，然后作为item传给pipeline处理。
3. 数据库保存
未完成，目前**对IEEE的文章**保存了 paper, researcher, paper_researcher, domain, paper_domain这几张表 

测试时建议在爬取IEEE（`scrapy crawl IEEE_Paper`）之后（未毕全爬完，可以只爬一部分文章），然后将test_files/crawled_items.json重命名为crawled_items_debug.json, 然后使用`scrapy crawl debug`，这样可以不必每次都向IEEE发送请求，就比较快。