### PR TITLE
feat(pipeline): 保存无法及时获得 doi 的 reference 到数据库用于之后的进一步爬取。

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,14 +236,43 @@ TODO: 目前对IEEE的处理是将title作为id保存，目前不确定是否能
 |  1   | `rid` | researcher id  | varchar(255) | PRI  |  NO  |      |        |
 |  2   | `aid` | affiliation id | varchar(255) | PRI  |  NO  |      |        |
 
-##### 10. researcher_domain
+##### *10. researcher_domain **弃用***
+
+由于 researcher domain 就是某研究者的所有文章的 domain 的集合，故不在数据爬取时就进行保存这种冗余数据表。
 
 | 序号 |  名称   |     描述      |     类型     |  键  | 为空 | 额外 | 默认值 |
 | :--: | :-----: | :-----------: | :----------: | :--: | :--: | :--: | :----: |
 |  1   |  `rid`  | researcher id | varchar(255) | PRI  |  NO  |      |        |
 |  2   | `dname` |  domain name  | varchar(255) | PRI  |  NO  |      |        |
 
+#####  11. paper_reference_citation
 
+存储暂时只能获得citation的reference，用于之后的进一步爬取
+
+| 序号 |         名称         |                          描述                           |     类型      |  键  | 为空 |      额外      | 默认值 |
+| :--: | :------------------: | :-----------------------------------------------------: | :-----------: | :--: | :--: | :------------: | :----: |
+|  1   |         `id`         | 自增id，没什么意义，只是由于citation比较长，无法作为key |      int      | PRI  |  NO  | auto_increment |        |
+|  2   |        `pid`         |                                                         | varchar(255)  |      |  NO  |                |        |
+|  3   | `reference_citation` |                                                         | varchar(4095) |      |  NO  |                |        |
+
+##### 12.  paper_reference_title
+
+存储暂时只能获得title的reference（存titile主要是因为IEEE给出的citation很奇怪，还不如title），用于之后的进一步爬取
+
+| 序号 |       名称        |                         描述                         |     类型      |  键  | 为空 |      额外      | 默认值 |
+| :--: | :---------------: | :--------------------------------------------------: | :-----------: | :--: | :--: | :------------: | :----: |
+|  1   |       `id`        | 自增id，没什么意义，只是由于title比较长，无法作为key |      int      | PRI  |  NO  | auto_increment |        |
+|  2   |       `pid`       |                                                      | varchar(255)  |      |  NO  |                |        |
+|  3   | `reference_title` |                                                      | varchar(4095) |      |  NO  |                |        |
+
+##### 13. paper_ieee_reference_document
+
+存储暂时只能获得IEEE内部编号的reference，用于之后的进一步爬取
+
+| 序号 |      名称       | 描述 |     类型     |  键  | 为空 | 额外 | 默认值 |
+| :--: | :-------------: | :--: | :----------: | :--: | :--: | :--: | :----: |
+|  1   |      `pid`      |      | varchar(255) | PRI  |  NO  |      |        |
+|  2   | `ieee_document` |      | varchar(255) | PRI  |  NO  |      |        |
 
 ## 其他设置
 

--- a/data_crawler/items.py
+++ b/data_crawler/items.py
@@ -24,6 +24,9 @@ class PaperItem(scrapy.Item):
     publicationYear = scrapy.Field()
     references = scrapy.Field() # 引用的文章的doi（可以获得doi的）
     keywords = scrapy.Field() # keyword list
+    ref_ieee_document = scrapy.Field() # IEEE document id, stored to be crawled later
+    ref_title = scrapy.Field() # reference title, stored to be crawled later. Store this beacause citation that IEEE gives is weired.
+    ref_citation = scrapy.Field()
 
 class IEEEPaperItem(scrapy.Item):
     title = scrapy.Field()

--- a/data_crawler/settings.py
+++ b/data_crawler/settings.py
@@ -38,6 +38,17 @@ IEEE_YEAR = {
     'from': 2019,
     'to': 2019
 }
+
+# google scholar（由于不可描述的原因，使用南大的镜像站，但是对没个ip初次使用要进行验证）
+GOOGLE_SCHOLAR_URL = 'https://g0.njuu.cf/extdomains/scholar.google.com/scholar?hl=en&as_sdt=0%2C5&q='
+# 是从SEARCH_WORDS搜索还是从数据库获取要搜索的关键词
+FROM_DB = False
+# 搜索用的关键词，事实上是citation
+SEARCH_WORDS = [
+    'Robin Abraham and Martin Erwig. 2006. Inferring Templates from Spreadsheets. In International Conference on Software Engineering (ICSE), 182–191.'
+]
+
+
 # Database
 MYSQL_HOST = 'localhost'
 MYSQL_DBNAME = 'data_processing'

--- a/data_processing.sql
+++ b/data_processing.sql
@@ -65,14 +65,29 @@ CREATE TABLE `paper_publication` (
     PRIMARY KEY (`paper_id`, `publication_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
-CREATE TABLE `researcher_domain` (
-    `rid` varchar(255) COLLATE utf8_bin NOT NULL,
-    `dname` varchar(255) COLLATE utf8_bin NOT NULL,
-    PRIMARY KEY (`rid`, `dname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
 CREATE TABLE `researcher_affiliation` (
     `rid` varchar(255) COLLATE utf8_bin NOT NULL,
     `aid` varchar(255) COLLATE utf8_bin NOT NULL,
     PRIMARY KEY (`rid`, `aid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+
+CREATE TABLE `paper_ieee_reference_document` (
+    `pid` varchar(255) COLLATE utf8_bin NOT NULL,
+    `ieee_document` varchar(255) COLLATE utf8_bin NOT NULL,
+    PRIMARY KEY (`pid`, `ieee_document`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+
+CREATE TABLE `paper_reference_citation` (
+    `id` int(11) NOT NULL AUTO_INCREMENT,
+    `pid` varchar(255) COLLATE utf8_bin NOT NULL,
+    `reference_citation` varchar(4095) COLLATE utf8_bin NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin AUTO_INCREMENT=5212;
+
+CREATE TABLE `paper_reference_title` (
+    `id` int(11) NOT NULL AUTO_INCREMENT,
+    `pid` varchar(255) COLLATE utf8_bin NOT NULL,
+    `reference_title` varchar(4095) COLLATE utf8_bin NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin AUTO_INCREMENT=314;


### PR DESCRIPTION
1. 保存无法及时获得 doi 的 reference 到数据库用于之后的进一步爬取
具体来说存到三个表中，分别是 paper_reference_citation, paper_reference_title, paper_ieee_reference_document. 有的保存标题有的保存 citation 是由于IEEE给的 citation 格式奇怪难以搜索，还不如 title。

2. 删除了数据库中的一张冗余表 researcher_domain。
由于 researcher domain 就是某研究者的所有文章的 domain 的集合，故不在数据爬取时就进行保存这种冗余数据表。

3. 删除了IEEEMysqlPipeline。其功能完全被UnifyPaperMysqlPipeline代替，统一对 ACM, IEEE 文章进行处理。