### PR TITLE
feat(acm_spider): 增加 acm 期刊爬取功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,16 +83,16 @@ IEEE_JOURNAL_YEAR = {
 
 #### result
 
-IEEE_CONF_URLS 中所有会议在 IEEE_YEAR 范围内的所有文章
+爬取 IEEE_CONF_URLS 中所有会议在 IEEE_YEAR 范围内的所有文章
 
-IEEE_JOURNAL_URLS 中所有期刊在 IEEE_JOURNAL_YEAR 范围内的所有文章
+爬取 IEEE_JOURNAL_URLS 中所有期刊在 IEEE_JOURNAL_YEAR 范围内的所有文章
 
-### ACM proceeding crawler
+### ACM crawler
 
 #### command
 
 ```shell
-scrapy crawl ACM_Proceedings
+scrapy crawl ACM_Proceedings_Journals
 ```
 
 #### settings
@@ -100,14 +100,28 @@ scrapy crawl ACM_Proceedings
 /data_crawler/settings.py
 
 ```python
-ACM_PROCEEDING_URL = ['https://dl.acm.org/doi/proceedings/10.1145/3238147']
+### ACM conference proceeding urls
+ACM_PROCEEDING_URLS = [
+    'https://dl.acm.org/doi/proceedings/10.1145/3238147'
+]
+### ACM journals
+ACM_JOURNAL_URLS = [
+    'https://dl.acm.org/loi/tosem'
+]
+### 需要的年份(including 'from' and 'to')
+ACM_JOURNAL_YEAR = {
+    'from': 2019,
+    'to': 2019
+}
 ```
 
 可以是多个proceeding
 
 #### result
 
-爬取settings中所有proceeding的所有文章
+爬取 ACM_PROCEEDING_URLS 中的所有文章
+
+爬取 ACM_JOURNAL_URLS 中 journal 在 ACM_JOURNAL_YEAR 范围内的所有文章
 
 ### DEBUG crawler
 
@@ -121,7 +135,7 @@ scrapy crawl debug
 
 #### settings
 
-在test_files/crawled_items_debug.json中放入之前爬的raw json结果
+在test_files/crawled_items_debug.json 中放入之前爬的 raw json 结果
 
 #### result
 
@@ -157,7 +171,7 @@ scrapy crawl debug
    ```python
    ITEM_PIPELINES = {
        'data_crawler.pipelines.RemoveEmptyItemPipeline': 500,
-    'data_crawler.pipelines.JsonWriterPipeline': 888 if not DEBUG else None,
+    	'data_crawler.pipelines.JsonWriterPipeline': 888 if not DEBUG else None,
        'data_crawler.pipelines.MysqlPipeline': 889,
    }
    ```
@@ -211,16 +225,12 @@ TODO: 目前来看，ieee没有affliation的页面，因此也似乎没有内部
 
 ##### 5. publication
 
-TODO: 目前不确定是否所有的会议都有doi，如果没有的话考虑通过其他方式存储
-
-TODO: 目前对IEEE的处理是将title作为id保存，目前不确定是否能从 ieee 获得会议doi. 
-
-| 序号 |        名称        |                             描述                             |     类型     |  键  | 为空 | 额外 | 默认值 |
-| :--: | :----------------: | :----------------------------------------------------------: | :----------: | :--: | :--: | :--: | :----: |
-|  1   |        `id`        | 会议 id, 可能通过 doi 编码得到, 也可能用内部 id 标识, 需要进一步考虑。注意是具体某一年的会议，比如第34届ASE，不是历年的ASE汇总的（那个可能没有doi） | varchar(255) | PRI  |  NO  |      |        |
-|  2   |       `name`       |                                                              | varchar(255) |      |  NO  |      |        |
-|  3   | `publication_date` |                          发表的年份                          | varchar(255) |      |  NO  |      |        |
-|  4   |      `impact`      |            影响力因子（TODO:目前不知道怎么获得）             | varchar(255) |      |  NO  |      |        |
+| 序号 |        名称        |                 描述                  |     类型     |  键  | 为空 | 额外 | 默认值 |
+| :--: | :----------------: | :-----------------------------------: | :----------: | :--: | :--: | :--: | :----: |
+|  1   |        `id`        |        使用对应数据库的内部 id        | varchar(255) | PRI  |  NO  |      |        |
+|  2   |       `name`       |                                       | varchar(255) |      |  NO  |      |        |
+|  3   | `publication_date` |              发表的年份               | varchar(255) |      |  NO  |      |        |
+|  4   |      `impact`      | 影响力因子（TODO:目前不知道怎么获得） | varchar(255) |      |  NO  |      |        |
 
 
 ##### 6. paper_reference

--- a/data_crawler/items.py
+++ b/data_crawler/items.py
@@ -49,7 +49,9 @@ class ACMPaperItem(scrapy.Item):
     title = scrapy.Field() # 标题
     authors = scrapy.Field() # 作者
     month_year = scrapy.Field() # 月份和年份
-    conference = scrapy.Field() # 会议/期刊
+    # conference = scrapy.Field() # 会议/期刊
+    publication_id = scrapy.Field() # ACM 内部 id，对于会议来说是会议 publication doi，对于期刊（每一个 issue 都没有 doi）来说是一个内部id，如'/toc/tosem/2015/25/1',表示 tosem 2015年 volume 25 issue 1,可以唯一确定一个 issue。
+    publication_title = scrapy.Field()
     doi = scrapy.Field()
     abstract = scrapy.Field()
     citation = scrapy.Field() # paper citation

--- a/data_crawler/pipelines.py
+++ b/data_crawler/pipelines.py
@@ -74,8 +74,10 @@ class ACMPaper2UnifyPipeline:
         paper_authors = []
         for author in item['authors']:
             order += 1
+            author_profile_sp = author['author_profile'].split('/profile/')
+            author_id = author_profile_sp[len(author_profile_sp) - 1]
             paper_author = {
-                'id': 'ACM_' + author['author_profile'][19:], # "dl.acm.org/profile/99659280949" removed 'dl.acm.org/profile/', 19 charactors
+                'id': 'ACM_' + author_id, # d.g. "/profile/99659280949"
                 'name': author['author_name'],
                 'order': order,
                 'affiliation': author['affiliation']
@@ -83,8 +85,8 @@ class ACMPaper2UnifyPipeline:
             paper_authors.append(paper_author)
         paper['authors'] = paper_authors        
         paper['abstract'] = item['abstract']
-        paper['publication_id'] = encode(item['conference']['conference_doi'])
-        paper['publicationTitle'] = item['conference']['conference_title']
+        paper['publication_id'] = encode(item['publication_id'])
+        paper['publicationTitle'] = item['publication_title']
         paper['doi'] = item['doi']
         paper['id'] = encode(item['doi'])
         paper['citation'] = item['citation']

--- a/data_crawler/settings.py
+++ b/data_crawler/settings.py
@@ -33,7 +33,7 @@ NEWSPIDER_MODULE = 'data_crawler.spiders'
 ACM_URL = ['https://dl.acm.org/action/doSearch?fillQuickSearch=false&expand=dl&field1=AllField&text1=shit&Ppub=%5B20200907+TO+20201007%5D'] 
 ### ACM conference proceeding urls
 ACM_PROCEEDING_URLS = [
-    # 'https://dl.acm.org/doi/proceedings/10.1145/3238147'
+    'https://dl.acm.org/doi/proceedings/10.1145/3238147'
 ]
 ### ACM journals
 ACM_JOURNAL_URLS = [

--- a/data_crawler/settings.py
+++ b/data_crawler/settings.py
@@ -27,23 +27,36 @@ SPIDER_MODULES = ['data_crawler.spiders']
 NEWSPIDER_MODULE = 'data_crawler.spiders'
 
 # URL for Spider
-# TODO: 切换到需要爬取的url（某个search result）
-IEEE_URL = ['https://ieeexplore.ieee.org/document/']
-ACM_URL = ['https://dl.acm.org/action/doSearch?fillQuickSearch=false&expand=dl&field1=AllField&text1=shit&Ppub=%5B20200907+TO+20201007%5D'] # 填入ACM的地址
-ACM_PROCEEDING_URLS = ['https://dl.acm.org/doi/proceedings/10.1145/3238147']
 
-# IEEE
-# IEEE conferences
+## ACM
+### ACM search result urls
+ACM_URL = ['https://dl.acm.org/action/doSearch?fillQuickSearch=false&expand=dl&field1=AllField&text1=shit&Ppub=%5B20200907+TO+20201007%5D'] 
+### ACM conference proceeding urls
+ACM_PROCEEDING_URLS = [
+    # 'https://dl.acm.org/doi/proceedings/10.1145/3238147'
+]
+### ACM journals
+ACM_JOURNAL_URLS = [
+    'https://dl.acm.org/loi/tosem'
+]
+### 需要的年份(including 'from' and 'to')
+ACM_JOURNAL_YEAR = {
+    'from': 2019,
+    'to': 2019
+}
+
+## IEEE
+### IEEE conferences
 IEEE_CONF_URLS = [
     'https://ieeexplore.ieee.org/xpl/conhome/1000064/all-proceedings'
 ]
-# 需要的年份(including 'from' and 'to')
+### 需要的年份(including 'from' and 'to')
 IEEE_YEAR = {
     'from': 2019,
     'to': 2019
 }
-# IEEE journal
-# journal 主页的 url。事实上只需要 punumber
+## IEEE journal
+### journal 主页的 url。事实上只需要 punumber
 IEEE_JOURNAL_URLS = [
     'https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=32'
 ]

--- a/data_crawler/spiders/acm_proceedings_spider.py
+++ b/data_crawler/spiders/acm_proceedings_spider.py
@@ -20,24 +20,83 @@ from urllib.parse import urlencode
 
 class ACMProceedingSpider(scrapy.Spider):
     name = "ACM_Proceedings"
-    allowed_domains = ["dl.acm.org"]
-    start_urls = get_project_settings().get('ACM_PROCEEDING_URLS')
-
-    def __init__(self):
-        super(ACMProceedingSpider, self).__init__()
-        self.startPage = 0
-        self.pageSize = 20 # ACM advanced search默认每页显示20篇文章。也许以后会变动
-
-    def parse(self, response):
+    acm_base_url = 'https://dl.acm.org'
+    allowed_domains = ['dl.acm.org']
+    proceeding_urls = get_project_settings().get('ACM_PROCEEDING_URLS')
+    journal_urls = get_project_settings().get('ACM_JOURNAL_URLS')
+    journal_year = get_project_settings().get('ACM_JOURNAL_YEAR')
+    
+    def start_requests(self):
+        for url in self.proceeding_urls:
+            yield scrapy.Request(
+                url=url,
+                callback=self.parse_proceedings,
+                dont_filter=True
+            )
+        
+        for url in self.journal_urls:
+            yield scrapy.Request(
+                url=url,
+                callback=self.parse_journals,
+                dont_filter=True
+            )
+    
+    def parse_journals(self, response):
         """
-        由于ACM proceeding页面使用懒加载，需要
-        1. 获取必要的用于模拟懒加载请求的，不知道什么意思的request payload, pbContext.
+        由于 ACM journal 页面使用懒加载，需要
+        1. 获取必要的用于模拟懒加载请求的，不知道什么意思的 request payload: pbContext.
+        2. 目标组件的 widgetId 是一个固定的值(所有期刊对应展示历史期刊的组件 widget id 都是 'ece68bd8-5742-40fc-b952-a19a9548dc74')
+        3. 获取 journal doi
+        3. 按照设定的年份要求依次爬取。
+        """
+        pbContext = response.xpath('./head/meta/@content').get()
+        widgetId = 'ece68bd8-5742-40fc-b952-a19a9548dc74'
+        doi = response.xpath('.//div[@data-widget-id="ece68bd8-5742-40fc-b952-a19a9548dc74"]/@data-journal-doi').get()
+        
+        for year in range(self.journal_year['from'], self.journal_year['to'] + 1):
+            query_string_param = {
+                'widgetId': widgetId,
+                'pbContext': pbContext,
+                'doi': doi,
+                'decadeRange': str(year - year % 10) + '-' + str(year - year % 10 + 9), # e.g. 2010-2019
+                'yearParam': year
+            }
+            yield scrapy.Request(
+                url='https://dl.acm.org/pb/widgets/loi/loiAjax?' + urlencode(query_string_param),
+                callback=self.parse_journals_year
+            )
+        yield None
+    
+    def parse_journals_year(self, response):
+        issue_urls = response.xpath('.//a[@class="loi__issue"]/@href').getall()
+        for issue_url in issue_urls:
+            yield scrapy.Request(
+                url=self.acm_base_url + issue_url,
+                callback=self.parse_journals_issue
+            )
+
+    def parse_journals_issue(self, response):
+        self.logger.info('start crawling journal issue: {}'.format(response.request.url))
+        issues = response.xpath('.//div[@class="issue-item-container"]')
+        for issue in issues:
+            if(issue.xpath('.//div[@class="issue-item__citation"]/div[@class="issue-heading"]/text()').get() == 'research-article'):
+                issue_url = issue.xpath('.//h5[@class="issue-item__title"]/a/@href').get()
+                yield scrapy.Request(
+                    url=self.acm_base_url + issue_url,
+                    callback=self.parse_paper
+                )
+
+
+
+    def parse_proceedings(self, response):
+        """
+        由于 ACM proceeding 页面使用懒加载，需要
+        1. 获取必要的用于模拟懒加载请求的，不知道什么意思的request payload: pbContext.
         2. 获得目标组件（SESSIONS列表）的widgetId
         3. 获得ssession
         4. 对每个session，获取head id
         5. 依次请求每个session
         6. 对每个session的所有文章依次爬取文章界面。
-        
         """
         # request payload for lazy loading
         pbContext = response.xpath('./head/meta/@content').get()
@@ -78,4 +137,91 @@ class ACMProceedingSpider(scrapy.Spider):
             )
     
     def parse_paper(self, response):
-        yield parse_acm_paper(self, response)
+        def parse_index_tree(selector):
+            """传入一个树的select，返回树的json
+            """
+            # 前置条件：根节点存在（selector.get() != None）。对根结点没关系
+            result = {}
+            result['title'] = selector.xpath('./div/p/a/text()').get() or selector.xpath('./h6/text()').get()
+            result['url'] = 'https://dl.acm.org/' + selector.xpath('./div/p/a/@href').get()
+            child = []
+            for child_html in selector.xpath('./ol[contains(@class, hasNodes)]/li').getall():
+                child.append(parse_index_tree(scrapy.Selector(text=child_html).xpath('./body/li')))
+            result['child'] = child
+            return result
+
+        # 结果的对象
+        result = ACMPaperItem()
+        paper = response.xpath('//article')
+
+        result['title'] = paper.xpath('.//div[@class="citation"]//h1[@class="citation__title"]/text()').get()
+
+        # authors
+        result['authors'] = []
+        authors = paper.xpath('.//div[@class="citation"]//div[@id="sb-1"]/ul/li[@class="loa__item"]')
+        for author in authors:
+            result_author = {
+                'author_name': author.xpath('.//span[@class="loa__author-name"]/span/text()').get(),
+                'author_profile': author.xpath('//div[@class="author-info"]//div[@class="author-info__body"]/a/@href').get(),
+                'affiliation': author.xpath('.//div[@class="author-info__body"]/p/text()').getall()
+            }
+            result['authors'].append(result_author)
+
+        # 获得发表的相关信息
+        publication = paper.xpath('.//div[@class="issue-item__detail"]')
+
+        # 会议名和会议doi
+        try:
+            conference = {
+                'conference_title': publication.xpath('./a/@title').get(), 
+                'conference_doi': remove_prefix(publication.xpath('./a/@href').get(), '/doi/proceedings/')
+            }
+        except NoPrefixException as e:
+            # conference的doi如果不包含这个前缀的话，全部保存并发出warning。
+            self.logger.warning('conference doi without prefix \'/doi/proceedings/\', got %s, saved as doi instead' % e.args[0])
+            conference = {
+                'conference_title': publication.xpath('./a/@title').get(), 
+                'conference_doi': publication.xpath('./a/@href').get()
+            }
+        result['conference'] = conference
+
+        # paper发表年月
+        result['month_year'] = publication.xpath('.//span[@class="epub-section__date"]/text()').get()
+
+        # paper doi
+        try:
+            result['doi'] = remove_prefix(response.request.url, 'https://doi.org/doi/')
+        except NoPrefixException as e:
+            self.logger.warning('paper url without prefix \'https://doi.org/doi/\', got %s instead, saved as doi instead' % e.args[0])
+            result['doi'] = response.request.url
+
+        # paper abstract
+        result['abstract'] = paper.xpath('.//div[@class="abstractSection abstractInFull"]/p/text()').get()
+        
+        # paper references
+        references_selectors = paper.xpath('.//div[contains(@class, "article__references")]/ol[contains(@class, "references__list")]/li/span[@class="references__note"]')
+        result['references'] = [
+            {
+                'reference_citation': reference.xpath('./text()').get(),
+                'reference_links': [{
+                        'link_type': link.xpath('./span[@class="visibility-hidden"]/text()').get(),
+                        'link_url': link.xpath('./@href').get()
+                    }
+                    for link in reference.xpath('./span[@class="references__suffix"]/a')
+                ]
+            } for reference in references_selectors
+        ]
+
+        # index term
+        root_selector = response.xpath('.//ol[@class="rlist organizational-chart"]/li')
+        result['index_term_tree'] = {
+            'title': root_selector.xpath('./h6/text()').get(),
+            'url': None,
+            'child': [parse_index_tree(scrapy.Selector(text=tree_html).xpath('./body/li')) for tree_html in root_selector.xpath('./ol/li').getall()]
+        }
+
+        # metric citation number
+        result['citation'] = response.xpath('//span[@class="citation"]/span/text()').get()
+
+        self.logger.info("paper crawled, doi: {}".format(result['doi']))
+        yield result

--- a/data_crawler/spiders/acm_spider.py
+++ b/data_crawler/spiders/acm_spider.py
@@ -19,7 +19,7 @@ from data_crawler.spiders.acm_paper_parser import parse_acm_paper
 from urllib.parse import urlencode
 
 class ACMProceedingSpider(scrapy.Spider):
-    name = "ACM_Proceedings"
+    name = "ACM_Proceedings_Journals"
     acm_base_url = 'https://dl.acm.org'
     allowed_domains = ['dl.acm.org']
     proceeding_urls = get_project_settings().get('ACM_PROCEEDING_URLS')

--- a/data_crawler/spiders/ieee_spider.py
+++ b/data_crawler/spiders/ieee_spider.py
@@ -19,11 +19,6 @@ class IEEESpider(scrapy.Spider):
     journal_urls = get_project_settings().get('IEEE_JOURNAL_URLS')
     journal_year = get_project_settings().get('IEEE_JOURNAL_YEAR')
     ieee_base_url = 'https://ieeexplore.ieee.org'
-
-    def __init__(self):
-        super(IEEESpider, self).__init__()
-        self.startPage = 0
-        self.pageSize = 25 # IEEE advanced search默认每页显示25篇文章。也许以后会变动
     
     def start_requests(self):
         # crawl conferences


### PR DESCRIPTION
1. 爬取 ACM 期刊
2. 将 parse_acm_paper 方法放回 acm_spier。 acm_proceedings_spider 改为 acm_spider
    之前对于 spider 的理解有误，如果两个爬取相同网站的 spider 有公共的方法，不应该把它抽象为一个公共的方法，而是应该把两个 spider 合并
3. publication id 改为 内部 id（原来对于 ACM，是存 publication doi）
    原因是对于期刊，并不是每个 issue 都有 doi；之前爬会议的时候由于每个 issue 都有 doi 故保存的是 doi，现在统一改为内部 id。这个在 #15 中进行了详细说明

注意，ACM 的爬取命令改为了 `scrapy crawl ACM_Proceedings_Journals`，会同时爬取会议和期刊。